### PR TITLE
Update/packagecloud provider

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,7 @@ class varnish::config {
   case $::osfamily {
     'RedHat', 'Amazon': {
       case $::varnish::varnish_version {
-        '3.0': {
+        /3.[0-1]/: {
           $sysconfig_template = "varnish/el${::operatingsystemmajrelease}/varnish-3.sysconfig.erb"
         }
         default: {
@@ -18,10 +18,10 @@ class varnish::config {
 
     'Debian': {
       case $::varnish::varnish_version {
-        '3.0': {
+        /3.[0-1]/: {
           $sysconfig_template = 'varnish/debian/varnish-3.default.erb'
         }
-        '4.0': {
+        /4.[0-1]/: {
           $sysconfig_template = 'varnish/debian/varnish-4.default.erb'
         }
         default: {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,6 +24,9 @@ class varnish::config {
         /4.[0-1]/: {
           $sysconfig_template = 'varnish/debian/varnish-4.default.erb'
         }
+        /5.[0-1]/: {
+          $sysconfig_template = 'varnish/debian/varnish-5.default.erb'
+        }
         default: {
           fail("Varnish version ${::varnish::varnish_version} not supported on ${::operatingsystem} (${::lsbdistdescription}, ${::lsbdistcodename})")
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,7 +68,7 @@ class varnish (
   unless is_integer($max_threads) { fail('max_threads invalid') }
   validate_absolute_path($storage_file)
   validate_hash($runtime_params)
-  validate_re($varnish_version, '^[3-4]\.[0-1]')
+  validate_re($varnish_version, '^[3-5]\.[0-1]')
   validate_re($storage_type, '^(malloc|file)$')
 
   if ($addrepo) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,18 +7,17 @@ class varnish::params {
 
   case $::osfamily {
     'RedHat': {
+      $repoclass          = 'varnish::repo::redhat'
 
       case $::operatingsystemmajrelease {
         '6': {
           $addrepo            = true
-          $repoclass          = "varnish::repo::el${::operatingsystemmajrelease}"
           $sysconfig          = '/etc/sysconfig/varnish'
           $varnish_version    = '3.0'
           $vcl_reload         = '/usr/bin/varnish_reload_vcl'
         }
         '7': {
           $addrepo            = true
-          $repoclass          = "varnish::repo::el${::operatingsystemmajrelease}"
           $sysconfig          = '/etc/varnish/varnish.params'
           $varnish_version    = '4.0'
           $vcl_reload         = '/usr/sbin/varnish_reload_vcl'
@@ -26,7 +25,6 @@ class varnish::params {
         default: {
           # Amazon Linux
           $addrepo            = true
-          $repoclass          = "varnish::repo::el${::operatingsystemmajrelease}"
           $sysconfig          = '/etc/sysconfig/varnish'
           $varnish_version    = '3.0'
           $vcl_reload         = '/usr/sbin/varnish_reload_vcl'
@@ -34,6 +32,7 @@ class varnish::params {
       }
     }
     'Debian': {
+      $repoclass          = 'varnish::repo::debian'
       case $::lsbdistcodename {
         'precise': {
           $addrepo            = false
@@ -44,7 +43,6 @@ class varnish::params {
         }
         'trusty': {
           $addrepo            = true
-          $repoclass          = 'varnish::repo::debian'
           $sysconfig          = '/etc/default/varnish'
           $varnish_version    = '4.0'
           $vcl_reload         = '/usr/share/varnish/reload-vcl'
@@ -52,7 +50,6 @@ class varnish::params {
         }
         'wheezy': {
           $addrepo            = true
-          $repoclass          = 'varnish::repo::debian'
           $sysconfig          = '/etc/default/varnish'
           $varnish_version    = '3.0'
           $vcl_reload         = '/usr/share/varnish/reload-vcl'
@@ -60,7 +57,6 @@ class varnish::params {
         }
         'jessie': {
           $addrepo            = true
-          $repoclass          = 'varnish::repo::debian'
           $sysconfig          = '/etc/default/varnish'
           $varnish_version    = '4.0'
           $vcl_reload         = '/usr/share/varnish/reload-vcl'

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -4,13 +4,13 @@ class varnish::repo::debian {
 
     $ver = delete($::varnish::varnish_version,'.')
 
-    ::packagecloud::repo { "varnish-cache":
-      fq_name => "varnishcache/varnish$ver",
-      type => 'deb',
+    ::packagecloud::repo { 'varnish-cache':
+      fq_name => "varnishcache/varnish${ver}",
+      type    => 'deb',
     }
 
     exec { 'varnish-cache apt-update':
-      command => 'apt-get update',
+      command     => 'apt-get update',
       refreshonly => true,
       subscribe   => Packagecloud::Repo['varnish-cache'],
       path        => '/usr/bin:/usr/sbin',

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -3,12 +3,19 @@ class varnish::repo::debian {
     include ::apt
 
     ::apt::source { 'varnish-cache':
-        comment  => 'Apt source for Varnish 4',
+        comment  => "Apt source for Varnish ${::varnish::varnish_version}",
         location => 'http://repo.varnish-cache.org/debian',
         repos    => "varnish-${::varnish::varnish_version}",
         key      => {
           source => 'https://repo.varnish-cache.org/GPG-key.txt',
           id     => 'E98C6BBBA1CBC5C3EB2DF21C60E7C096C4DEFFEB',
         },
+    }
+
+    exec { 'varnish-cache apt-update':
+      command => 'apt-get update',
+      refreshonly => true,
+      subscribe   => Apt::Source['varnish-cache'],
+      path        => '/usr/bin:/usr/sbin',
     }
 }

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -1,21 +1,20 @@
 # Add the Varnish repo
 class varnish::repo::debian {
-    include ::apt
+    include ::packagecloud
 
-    ::apt::source { 'varnish-cache':
-        comment  => "Apt source for Varnish ${::varnish::varnish_version}",
-        location => 'http://repo.varnish-cache.org/debian',
-        repos    => "varnish-${::varnish::varnish_version}",
-        key      => {
-          source => 'https://repo.varnish-cache.org/GPG-key.txt',
-          id     => 'E98C6BBBA1CBC5C3EB2DF21C60E7C096C4DEFFEB',
-        },
+    $version = "${::varnish::varnish_version}"
+
+    $ver = inline_template('<%= @version.sub(".","") %>')
+
+    ::packagecloud::repo { "varnish-cache":
+      fq_name => "varnishcache/varnish$ver",
+      type => 'deb',
     }
 
     exec { 'varnish-cache apt-update':
       command => 'apt-get update',
       refreshonly => true,
-      subscribe   => Apt::Source['varnish-cache'],
+      subscribe   => Packagecloud::Repo['varnish-cache'],
       path        => '/usr/bin:/usr/sbin',
     }
 }

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -2,9 +2,7 @@
 class varnish::repo::debian {
     include ::packagecloud
 
-    $version = "${::varnish::varnish_version}"
-
-    $ver = inline_template('<%= @version.sub(".","") %>')
+    $ver = delete($::varnish::varnish_version,'.')
 
     ::packagecloud::repo { "varnish-cache":
       fq_name => "varnishcache/varnish$ver",

--- a/manifests/repo/el6.pp
+++ b/manifests/repo/el6.pp
@@ -1,9 +1,0 @@
-# Add the Varnish repo
-class varnish::repo::el6 {
-  yumrepo { 'varnish-cache':
-    baseurl  => "https://repo.varnish-cache.org/redhat/varnish-${::varnish::varnish_version}/el6/",
-    descr    => 'Varnish-cache RPM repository',
-    enabled  => 1,
-    gpgcheck => 0
-  }
-}

--- a/manifests/repo/el7.pp
+++ b/manifests/repo/el7.pp
@@ -1,9 +1,0 @@
-# Add the Varnish repo
-class varnish::repo::el7 {
-  yumrepo { 'varnish-cache':
-    baseurl  => "https://repo.varnish-cache.org/redhat/varnish-${::varnish::varnish_version}/el7/",
-    descr    => 'Varnish-cache RPM repository',
-    enabled  => 1,
-    gpgcheck => 0
-  }
-}

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -1,0 +1,14 @@
+# Add the Varnish repo
+class varnish::repo::redhat {
+    include ::packagecloud
+
+    $version = "${::varnish::varnish_version}"
+
+    $ver = inline_template('<%= @version.sub(".","") %>')
+
+    ::packagecloud::repo { "varnish-cache":
+      fq_name => "varnishcache/varnish$ver",
+      type => 'rpm',
+    }
+
+}

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -2,13 +2,11 @@
 class varnish::repo::redhat {
     include ::packagecloud
 
-    $version = "${::varnish::varnish_version}"
+    $ver = delete($::varnish::varnish_version,'.')
 
-    $ver = inline_template('<%= @version.sub(".","") %>')
-
-    ::packagecloud::repo { "varnish-cache":
-      fq_name => "varnishcache/varnish$ver",
-      type => 'rpm',
+    ::packagecloud::repo { 'varnish-cache':
+      fq_name => "varnishcache/varnish${ver}",
+      type    => 'rpm',
     }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -39,6 +39,7 @@
     { "name": "puppet", "version_requirement": ">= 3.8.7" }
   ],
   "dependencies": [
+    { "name": "computology/packagecloud", "version_requirement": ">= 0.3.2" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 < 3.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=1.0.0 < 5.0.0" }
   ]

--- a/templates/debian/varnish-5.default.erb
+++ b/templates/debian/varnish-5.default.erb
@@ -1,0 +1,40 @@
+### This file created by Puppet, modification is probably futile
+
+# The Debian init script expects START, NFILES and MEMLOCK
+START=yes
+NFILES=131072
+MEMLOCK=82000
+
+RELOAD_VCL=1
+VARNISH_VCL_CONF=<%= scope['::varnish::vcl_conf'] %>
+VARNISH_LISTEN_ADDRESS=<%= scope['::varnish::listen'] %>
+VARNISH_LISTEN_PORT=<%= scope['::varnish::listen_port'] %>
+VARNISH_ADMIN_LISTEN_ADDRESS=<%= scope['::varnish::admin_listen'] %>
+VARNISH_ADMIN_LISTEN_PORT=<%= scope['::varnish::admin_port'] %>
+VARNISH_SECRET_FILE=<%= scope['::varnish::secret_file'] %>
+VARNISH_MIN_THREADS=<%= scope['::varnish::min_threads'] %>
+VARNISH_MAX_THREADS=<%= scope['::varnish::max_threads'] %>
+VARNISH_THREAD_TIMEOUT=<%= scope['::varnish::thread_timeout'] %>
+<% if scope['::varnish::storage_type'] == 'malloc' -%>
+VARNISH_STORAGE_FILE=malloc
+<% elsif scope['::varnish::storage_type'] == 'file' -%>
+VARNISH_STORAGE_FILE="file,<%= scope['::varnish::storage_file'] %>"
+<% end -%>
+VARNISH_STORAGE_SIZE=<%= scope['::varnish::storage_size'] %>
+VARNISH_STORAGE="${VARNISH_STORAGE_FILE},${VARNISH_STORAGE_SIZE}"
+VARNISH_USER=varnish
+VARNISH_GROUP=varnish
+VARNISH_TTL=120
+
+DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
+             -f ${VARNISH_VCL_CONF} \
+             -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
+             -t ${VARNISH_TTL} \
+             -p thread_pool_min=${VARNISH_MIN_THREADS} \
+             -p thread_pool_max=${VARNISH_MAX_THREADS} \
+             -p thread_pool_timeout=${VARNISH_THREAD_TIMEOUT} \
+             -S ${VARNISH_SECRET_FILE} \
+             -s ${VARNISH_STORAGE}"
+<% scope['::varnish::runtime_params'].each do |k,v| -%>
+DAEMON_OPTS="${DAEMON_OPTS} -p <%= k %>=<%= v %>"
+<% end -%>


### PR DESCRIPTION
A bit of reworking to switch to using the packagecloud repo for varnish packages

also updates the varnish version matching regexs to handle version 5.0/5.1 of varnish