### PR TITLE
[WIP] [Issue 40] Pick conf file template according to $addrepo, $package_ensure and available Varnish packages

### DIFF
--- a/lib/facter/varnish_version.rb
+++ b/lib/facter/varnish_version.rb
@@ -1,8 +1,10 @@
 Facter.add(:varnish_version) do
   confine :osfamily => 'redhat'
   setcode do
+    # If executable is available, use it to query installed version
     if Facter::Core::Execution.which('varnishd')
       Facter::Core::Execution.exec('varnishd -V 2>&1')[/varnish-([\d\.]+)/, 1]
+    # Otherwise, pick first* version listed from Yum
     else
       Facter::Core::Execution.exec('yum list varnish')[/varnish\S*\s*([\d\.]+)/, 1]
     end
@@ -12,10 +14,15 @@ end
 Facter.add(:varnish_version) do
   confine :osfamily => 'debian'
   setcode do
+    # If executable is available, use it to query installed version
     if Facter::Core::Execution.which('varnishd')
       Facter::Core::Execution.exec('varnishd -V 2>&1')[/varnish-([\d\.]+)/, 1]
+    # Otherwise, pick first* version listed from Apt
     else
       Facter::Core::Execution.exec('apt-cache show varnish')[/Version:\s*([\d\.]+)/, 1]
     end
   end
 end
+
+# * I'm optimistically assuming the first listed version
+# is the highest one available

--- a/lib/facter/varnish_version.rb
+++ b/lib/facter/varnish_version.rb
@@ -8,3 +8,14 @@ Facter.add(:varnish_version) do
     end
   end
 end
+
+Facter.add(:varnish_version) do
+  confine :osfamily => 'debian'
+  setcode do
+    if Facter::Core::Execution.which('varnishd')
+      Facter::Core::Execution.exec('varnishd -V 2>&1')[/varnish-([\d\.]+)/, 1]
+    else
+      Facter::Core::Execution.exec('apt-cache show varnish')[/Version:\s*([\d\.]+)/, 1]
+    end
+  end
+end

--- a/lib/facter/varnish_version.rb
+++ b/lib/facter/varnish_version.rb
@@ -1,9 +1,9 @@
 Facter.add(:varnish_version) do
   setcode do
     if Facter::Core::Execution.which('varnishd')
-      Facter::Core::Execution.exec('varnishd -V 2>&1')
+      Facter::Core::Execution.exec('varnishd -V 2>&1')[/varnish-([\d\.]+)/, 1]
     else
-      Facter::Core::Execution.exec('yum list varnish')
+      Facter::Core::Execution.exec('yum list varnish')[/varnish\S*\s*([\d\.]+)/, 1]
     end
   end
 end

--- a/lib/facter/varnish_version.rb
+++ b/lib/facter/varnish_version.rb
@@ -1,0 +1,9 @@
+Facter.add(:varnish_version) do
+  setcode do
+    if Facter::Core::Execution.which('varnishd')
+      Facter::Core::Execution.exec('varnishd -V')
+    else
+      Facter::Core::Execution.exec('yum list varnish')
+    end
+  end
+end

--- a/lib/facter/varnish_version.rb
+++ b/lib/facter/varnish_version.rb
@@ -1,4 +1,5 @@
 Facter.add(:varnish_version) do
+  confine :osfamily => 'redhat'
   setcode do
     if Facter::Core::Execution.which('varnishd')
       Facter::Core::Execution.exec('varnishd -V 2>&1')[/varnish-([\d\.]+)/, 1]

--- a/lib/facter/varnish_version.rb
+++ b/lib/facter/varnish_version.rb
@@ -1,7 +1,7 @@
 Facter.add(:varnish_version) do
   setcode do
     if Facter::Core::Execution.which('varnishd')
-      Facter::Core::Execution.exec('varnishd -V')
+      Facter::Core::Execution.exec('varnishd -V 2>&1')
     else
       Facter::Core::Execution.exec('yum list varnish')
     end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ class varnish::config {
   }
   # If user disabled Varnish repos, or available / installed version is newer,
   # than version provided by params, use available / installed version
-  elsif (addrepo == false or
+  elsif ($varnish::addrepo == false or
     versioncmp($varnish_available, $varnish::varnish_version) > 0) {
       $config_version = $varnish_available
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,9 +4,16 @@
 #
 class varnish::config {
 
-  $config_version = $varnish::package_ensure ? {
-    /^\d/   => $varnish::package_ensure,
-    default => $::varnish_version,
+  $varnish_available = $::varnish_version
+  if $varnish::package_ensure =~ /\d/ {
+    $config_version = $varnish::package_ensure
+  }
+  elsif (addrepo == false or
+    versioncmp($varnish_available, $varnish::varnish_version) > 0) {
+      $config_version = $varnish_available
+  }
+  else {
+    $config_version = $varnish::varnish_version
   }
 
   case $::osfamily {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,11 @@
 #
 class varnish::config {
 
+  $config_version = $varnish::package_ensure ? {
+    /^\d/   => $varnish::package_ensure,
+    default => $::varnish_version,
+  }
+
   case $::osfamily {
     'RedHat', 'Amazon': {
       case $::varnish::varnish_version {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,14 +4,21 @@
 #
 class varnish::config {
 
+  # Reads available or installed Varnish version from custom fact
   $varnish_available = $::varnish_version
+
+  # Choose conf file template version
+  # If user specified package_ensure, use this
   if $varnish::package_ensure =~ /\d/ {
     $config_version = $varnish::package_ensure
   }
+  # If user disabled Varnish repos, or available / installed version is newer,
+  # than version provided by params, use available / installed version
   elsif (addrepo == false or
     versioncmp($varnish_available, $varnish::varnish_version) > 0) {
       $config_version = $varnish_available
   }
+  # Otherwise, use version provided by params
   else {
     $config_version = $varnish::varnish_version
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,7 @@ class varnish::config {
 
   case $::osfamily {
     'RedHat', 'Amazon': {
-      case $::varnish::varnish_version {
+      case $config_version {
         /3.[0-1]/: {
           $sysconfig_template = "varnish/el${::operatingsystemmajrelease}/varnish-3.sysconfig.erb"
         }
@@ -22,7 +22,7 @@ class varnish::config {
     }
 
     'Debian': {
-      case $::varnish::varnish_version {
+      case $config_version {
         /3.[0-1]/: {
           $sysconfig_template = 'varnish/debian/varnish-3.default.erb'
         }
@@ -30,13 +30,13 @@ class varnish::config {
           $sysconfig_template = 'varnish/debian/varnish-4.default.erb'
         }
         default: {
-          fail("Varnish version ${::varnish::varnish_version} not supported on ${::operatingsystem} (${::lsbdistdescription}, ${::lsbdistcodename})")
+          fail("Varnish version ${config_version} not supported on ${::operatingsystem} (${::lsbdistdescription}, ${::lsbdistcodename})")
         }
       }
     }
 
     default: {
-      fail("Varnish version ${::varnish::varnish_version} not supported on ${::operatingsystem} (${::lsbdistdescription}, ${::lsbdistcodename})")
+      fail("Varnish version ${config_version} not supported on ${::operatingsystem} (${::lsbdistdescription}, ${::lsbdistcodename})")
     }
   }
 


### PR DESCRIPTION
This change adds some checks to match the config file template version to the actual Varnish package version installed:

- If user specifies a version in `$varnish::package_ensure` parameter, use template for this version
- If `$varnish::package_ensure` is unchanged and user disables Varnish repos with `$varnish::addrepo => false`
  - If Varnish is installed, use template for installed\* version
  - If not installed, use template for latest version available\* in the repos
- Otherwise, pick latest version between the one provided by class `varnish::params` and the installed\* or latest available\* one

\* I created a custom fact, `$::varnish_version`, which provides just that