### PR TITLE
Change default version to 4.1 for RHEL7 and derivatives and change the way the yum repo is declared.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class varnish::params {
         '7': {
           $addrepo            = true
           $sysconfig          = '/etc/varnish/varnish.params'
-          $varnish_version    = '4.0'
+          $varnish_version    = '4.1'
           $vcl_reload         = '/usr/sbin/varnish_reload_vcl'
         }
         default: {

--- a/manifests/repo/redhat.pp
+++ b/manifests/repo/redhat.pp
@@ -1,12 +1,14 @@
 # Add the Varnish repo
 class varnish::repo::redhat {
-    include ::packagecloud
 
     $ver = delete($::varnish::varnish_version,'.')
 
-    ::packagecloud::repo { 'varnish-cache':
-      fq_name => "varnishcache/varnish${ver}",
-      type    => 'rpm',
+    yumrepo { "varnish-cache-${ver}":
+      baseurl  => "https://packagecloud.io/varnishcache/varnish${ver}/el/\$releasever/\$basearch",
+      descr    => 'The varnish-cache repository',
+      enabled  => '1',
+      gpgcheck => '0',
+      gpgkey   => "https://packagecloud.io/varnishcache/varnish${ver}/gpgkey",
     }
 
 }


### PR DESCRIPTION
This pull request contains two changes:

1) Change the way the yum repo is declared
This patch is needed because the default package.io module doesn't support RHEL 7 and derivatives and we don't want to depend on another module if it is not needed. 

2) Default version for RHEL & derivatives is changed to 4.1
The packages in EPEL and Packagecloud are broken for version 7. 4.1 fixes these problems.
