### PR TITLE
Correct typo resulting in vcl_reload_cmd not being passed through properly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,7 @@ class varnish (
   if $vcl_reload_cmd == undef {
     $vcl_reload = $::varnish::params::vcl_reload
   } else {
-    $vcl_relaod = $vcl_reload_cmd
+    $vcl_reload = $vcl_reload_cmd
   }
 
   validate_bool($addrepo)


### PR DESCRIPTION
This corrects a simple typo which lead to the vcl_reload_cmd not being passed through when overridden via the top level class.