### PR TITLE
Varnish 4.1 on Centos 7.4 requires the reload command to be `/usr/sbin/varnish_reload_vcl`.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,8 @@ class varnish::params {
 
           if "${::varnish::version_major}.${::varnish::version_minor}" == '5.1' {
             $vcl_reload = '/sbin/varnish_reload_vcl'
+          } elsif "${::varnish::version_major}.${::varnish::version_minor}" == '4.1' {
+            $vcl_reload = '/usr/sbin/varnish_reload_vcl'
           } else {
             $vcl_reload = 'varnish_reload_vcl'
           }


### PR DESCRIPTION
systemd was failing to reload the Varnish service. Not sure if this is the best way of fixing it, however I know @craigwatson has been having much fun working out the compatibility issues with Varnish/OS versions etc.