### PR TITLE
This commit fixes the selinux-reference for the newest version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,6 +11,6 @@ fixtures:
       ref: "1.2.2"
     selinux:
       repo: "https://github.com/voxpupuli/puppet-selinux.git"
-      ref: "v0.8.0"
+      ref: "v1.5.2"
   symlinks:
     varnish: "#{source_dir}"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,10 +14,10 @@ class varnish::config {
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '6' and $::varnish::version_major != '3' {
     if $::selinux_current_mode == 'enforcing' {
       ::selinux::module { 'varnishpol':
-        ensure => present,
-        source => 'puppet:///modules/varnish/varnishpol.te',
-        before => Service[$::varnish::service_name],
-        notify => Service[$::varnish::service_name],
+        ensure    => present,
+        source_te => 'puppet:///modules/varnish/varnishpol.te',
+        before    => Service[$::varnish::service_name],
+        notify    => Service[$::varnish::service_name],
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -38,8 +38,8 @@
   "requirements": [ { "name": "puppet", "version_requirement": ">= 4.7.1 < 6.0.0" } ],
   "dependencies": [
     { "name": "stahnma/epel", "version_requirement": ">= 1.2.0 < 2.0.0" },
-    { "name": "puppet/selinux", "version_requirement": ">= 0.8.0 < 1.0.0" },
+    { "name": "puppet/selinux", "version_requirement": ">= 1.0.0 < 2.0.0" },
     { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 < 3.0.0" },
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=1.0.0 < 5.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=4.6.0 < 6.0.0" }
   ]
 }


### PR DESCRIPTION
The voxpupuli-selinux module changed from "source" to "source_te"
for .te files. Fixed that in this PR, also upped the version in
the metadata.json and .fixtures.yml. Also for puppetlabs-stdlib,
since this module is Puppet 4 only the stdlib needs to be at least
4.6.0 according to the README of the stdlib-module.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
