### PR TITLE
bump upper version limit of puppetlabs/apt dependency for Puppet 5 compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,7 +39,7 @@
   "dependencies": [
     { "name": "stahnma/epel", "version_requirement": ">= 1.2.0 < 2.0.0" },
     { "name": "puppet/selinux", "version_requirement": ">= 1.0.0 < 2.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 < 3.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 < 5.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=4.6.0 < 6.0.0" }
   ]
 }


### PR DESCRIPTION
Version 2.x of puppetlabs/apt is incompatible with Puppet 5.