### PR TITLE
Add support for version 6.0lts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,7 +57,7 @@ class varnish (
   Integer $min_threads                      = 50,
   Integer $max_threads                      = 1000,
   Integer $thread_timeout                   = 120,
-  Pattern[/^[3-6]\.[0-9]/] $varnish_version = '4.1',
+  Pattern[/^[3-6]\.[0-9](lts)?/] $varnish_version = '4.1',
   Optional[String] $instance_name           = undef,
   String $package_ensure                    = 'present',
   String $package_name                      = 'varnish',
@@ -77,6 +77,10 @@ class varnish (
     if $varnish_version != "${version_major}.${version_minor}" {
       fail("Version mismatch, varnish_version is ${varnish_version}, but package_ensure is ${version_full}")
     }
+  }
+  $version_lts   = $varnish_version ? {
+    /lts$/ => 'lts',
+    default => '',
   }
 
   include ::varnish::params

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,12 @@ class varnish::params {
     }
 
     'Debian': {
-      $vcl_reload = '/usr/share/varnish/reload-vcl'
+      $vcl_reload = $::varnish::version_major ? {
+        '6' => '/usr/sbin/varnishreload',
+        '5' => '/usr/share/varnish/reload-vcl -q',
+        '4' => '/usr/share/varnish/reload-vcl -q',
+        '3' => '/usr/share/varnish/reload-vcl -q',
+      }
       $sysconfig  = '/etc/default/varnish'
 
       case $::operatingsystem {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,7 +1,7 @@
 # Add the Varnish repo
 class varnish::repo {
 
-  $ver = "${::varnish::version_major}${::varnish::version_minor}"
+  $ver = "${::varnish::version_major}${::varnish::version_minor}${::varnish::version_lts}"
 
   case $::osfamily {
     'RedHat': {
@@ -67,19 +67,20 @@ class varnish::repo {
 
       $os_lower        = downcase($::operatingsystem)
       $package_require = Exec['apt_update']
-      $gpg_key_id      = "${::varnish::version_major}.${::varnish::version_minor}" ? {
-        '6.1' => '4A066C99B76A0F55A40E3E1E387EF1F5742D76CC',
-        '6.0' => '7C5B46721AF00FD57E68E6E8D2605BF74E8B9DBA',
-        '5.2' => '91CFD5635A1A5FAC0662BEDD2E9BA3FE86BE909D',
-        '5.1' => '54DC32329C37703D8B2819E6414C46826B880524',
-        '5.0' => '1487779B0E6C440214F07945632B6ED0FF6A1C76',
-        '4.1' => '9C96F9CA0DC3F4EA78FF332834BF6E8ECBF5C49E',
-        '4.0' => 'B7B16293AE0CC24216E9A83DD4E49AD8DE3FFEA4',
-        '3.0' => '246BE381150865E2DC8C6B01FC1318ACEE2C594C',
+      $gpg_key_id      = "${::varnish::version_major}.${::varnish::version_minor}${::varnish::version_lts}" ? {
+        '6.1'    => '4A066C99B76A0F55A40E3E1E387EF1F5742D76CC',
+        '6.0lts' => '48D81A24CB0456F5D59431D94CFCFD6BA750EDCD',
+        '6.0'    => '7C5B46721AF00FD57E68E6E8D2605BF74E8B9DBA',
+        '5.2'    => '91CFD5635A1A5FAC0662BEDD2E9BA3FE86BE909D',
+        '5.1'    => '54DC32329C37703D8B2819E6414C46826B880524',
+        '5.0'    => '1487779B0E6C440214F07945632B6ED0FF6A1C76',
+        '4.1'    => '9C96F9CA0DC3F4EA78FF332834BF6E8ECBF5C49E',
+        '4.0'    => 'B7B16293AE0CC24216E9A83DD4E49AD8DE3FFEA4',
+        '3.0'    => '246BE381150865E2DC8C6B01FC1318ACEE2C594C',
       }
 
       ::apt::source { 'varnish-cache':
-        comment  => "Apt source for Varnish ${::varnish::version_major}.${::varnish::version_minor}",
+        comment  => "Apt source for Varnish ${::varnish::version_major}.${::varnish::version_minor}${::varnish::version_lts}",
         location => "https://packagecloud.io/varnishcache/varnish${ver}/${os_lower}/",
         repos    => 'main',
         require  => Package['apt-transport-https'],


### PR DESCRIPTION
According to https://varnish-cache.org/releases/install_debian.html#install-debian there is a 6.0lts repository that should be used for the supported option.

This pull request adds support for it