### PR TITLE
Fix permissions of /etc/varnish/secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Release notes for the claranet/puppet-varnish module.
 
 ------------------------------------------
+## Unreleased
+  * Set permissions for `/etc/varnish/secret` to prevent varnish-agent startup issues as described [here](https://github.com/varnish/vagent2/issues/191)
 
 ## 5.0.1 - 2018-08-30
 

--- a/manifests/secret.pp
+++ b/manifests/secret.pp
@@ -8,8 +8,8 @@ class varnish::secret (
 
     file { $::varnish::secret_file:
       owner   => 'root',
-      group   => 'root',
-      mode    => '0600',
+      group   => 'varnish',
+      mode    => '0640',
       content => "${secret}\n",
     }
 
@@ -17,8 +17,8 @@ class varnish::secret (
 
     file { $::varnish::secret_file:
       owner => 'root',
-      group => 'root',
-      mode  => '0600',
+      group => 'varnish',
+      mode  => '0640',
     }
 
     exec { 'Generate Varnish secret file':


### PR DESCRIPTION
As in this Github issue: https://github.com/varnish/vagent2/issues/191
the permissions for /etc/varnish/secret needs to be 0640 and its owners
root:varnish to prevent problems with the starting order.

We ran into this problem with a varnish-plus cluster, where some varnish-agents don't start properly after a node was restarted.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
