### PR TITLE
Add 'stretch and above support', 'new gpgkeys for 62 63' and 'fix systemd unit file'

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,8 @@ BOXES = [
   { name: "debian7",  box: "debian/wheezy64",  version: "7.11.2" },
   { name: "debian8",  box: "debian/jessie64",  version: "8.11.0" },
   { name: "debian8",  box: "debian/stretch64", version: "9.8.0" },
+  { name: "debian9",  box: "debian/stretch64", version: "9.8.0" },
+  { name: "debian10", box: "debian/buster64",  version: "10.0.0" },
 
   { name: "ubuntu14", box: "ubuntu/trusty64", version: "20190301.0.1" },
   { name: "ubuntu16", box: "ubuntu/xenial64", version: "20190221.0.0" },

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,7 +42,7 @@ class varnish::params {
     'Debian': {
       if versioncmp($varnish::version_full,'6.1') >= 0 and versioncmp($::lsbdistrelease,'10.0') >= 0 {
         $vcl_reload = $::varnish::version_full ? {
-          /6.[1-5]/ => '/usr/share/varnish/varnishreload'
+          /6.[1-6]/ => '/usr/share/varnish/varnishreload'
         }
       }
       else{

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,11 +40,18 @@ class varnish::params {
     }
 
     'Debian': {
-      $vcl_reload = $::varnish::version_major ? {
-        '6' => '/usr/sbin/varnishreload',
-        '5' => '/usr/share/varnish/reload-vcl -q',
-        '4' => '/usr/share/varnish/reload-vcl -q',
-        '3' => '/usr/share/varnish/reload-vcl -q',
+      if versioncmp($varnish::version_full,'6.1') >= 0 {
+        $vcl_reload = $::varnish::version_full ? {
+          '6.1' => '/usr/share/varnish/varnishreload',
+        }
+      }
+      else{
+        $vcl_reload = $::varnish::version_major ? {
+          '6' => '/usr/sbin/varnishreload',
+          '5' => '/usr/share/varnish/reload-vcl -q',
+          '4' => '/usr/share/varnish/reload-vcl -q',
+          '3' => '/usr/share/varnish/reload-vcl -q',
+        }
       }
       $sysconfig  = '/etc/default/varnish'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,7 @@ class varnish::params {
     }
 
     'Debian': {
-      if versioncmp($varnish::version_full,'6.1') >= 0 {
+      if versioncmp($varnish::version_full,'6.1') >= 0 and versioncmp($::lsbdistrelease,'10.0') >= 0 {
         $vcl_reload = $::varnish::version_full ? {
           '6.1' => '/usr/share/varnish/varnishreload',
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,8 @@ class varnish::params {
       if versioncmp($varnish::version_full,'6.1') >= 0 and versioncmp($::lsbdistrelease,'10.0') >= 0 {
         $vcl_reload = $::varnish::version_full ? {
           '6.1' => '/usr/share/varnish/varnishreload',
+          '6.2' => '/usr/share/varnish/varnishreload',
+          '6.3' => '/usr/share/varnish/varnishreload',
         }
       }
       else{

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,9 +42,7 @@ class varnish::params {
     'Debian': {
       if versioncmp($varnish::version_full,'6.1') >= 0 and versioncmp($::lsbdistrelease,'10.0') >= 0 {
         $vcl_reload = $::varnish::version_full ? {
-          '6.1' => '/usr/share/varnish/varnishreload',
-          '6.2' => '/usr/share/varnish/varnishreload',
-          '6.3' => '/usr/share/varnish/varnishreload',
+          /6.[1-5]/ => '/usr/share/varnish/varnishreload'
         }
       }
       else{

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -60,8 +60,8 @@ class varnish::repo {
             fail('Varnish 5.0 from Packagecloud is not supported on Debian 7 (Wheezy)')
           }
 
-          if $::varnish::version_major == '6' and $::lsbdistcodename != 'stretch' {
-            fail('Varnish 6.0 and above is only supported on Debian 9 (Stretch)')
+          if $::varnish::version_major == '6' and versioncmp($::lsbdistrelease,'8.0') >= 0 {
+            fail('Varnish 6.0 and above is only supported on Debian 9 (Stretch) and above')
           }
         }
 
@@ -89,6 +89,8 @@ class varnish::repo {
       $os_lower        = downcase($::operatingsystem)
       $package_require = Exec['apt_update']
       $gpg_key_id      = "${::varnish::version_major}.${::varnish::version_minor}${::varnish::version_lts}" ? {
+        '6.3'    => '920A8A7AA7120A8604BCCD294A42CD6EB810E55D',
+        '6.2'    => 'B54813B54CA95257D3590B3F1B0096460868C7A9',
         '6.1'    => '4A066C99B76A0F55A40E3E1E387EF1F5742D76CC',
         '6.0lts' => '48D81A24CB0456F5D59431D94CFCFD6BA750EDCD',
         '6.0'    => '7C5B46721AF00FD57E68E6E8D2605BF74E8B9DBA',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -89,6 +89,8 @@ class varnish::repo {
       $os_lower        = downcase($::operatingsystem)
       $package_require = Exec['apt_update']
       $gpg_key_id      = "${::varnish::version_major}.${::varnish::version_minor}${::varnish::version_lts}" ? {
+        '6.5'    => 'A487F9BE81D9DF5121488CFE1C7B4E9FF149D65B',
+        '6.4'    => 'A9897320C397E3A60C03E8BF821AD320F71BFF3D'
         '6.3'    => '920A8A7AA7120A8604BCCD294A42CD6EB810E55D',
         '6.2'    => 'B54813B54CA95257D3590B3F1B0096460868C7A9',
         '6.1'    => '4A066C99B76A0F55A40E3E1E387EF1F5742D76CC',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -90,7 +90,7 @@ class varnish::repo {
       $package_require = Exec['apt_update']
       $gpg_key_id      = "${::varnish::version_major}.${::varnish::version_minor}${::varnish::version_lts}" ? {
         '6.5'    => 'A487F9BE81D9DF5121488CFE1C7B4E9FF149D65B',
-        '6.4'    => 'A9897320C397E3A60C03E8BF821AD320F71BFF3D'
+        '6.4'    => 'A9897320C397E3A60C03E8BF821AD320F71BFF3D',
         '6.3'    => '920A8A7AA7120A8604BCCD294A42CD6EB810E55D',
         '6.2'    => 'B54813B54CA95257D3590B3F1B0096460868C7A9',
         '6.1'    => '4A066C99B76A0F55A40E3E1E387EF1F5742D76CC',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -89,6 +89,7 @@ class varnish::repo {
       $os_lower        = downcase($::operatingsystem)
       $package_require = Exec['apt_update']
       $gpg_key_id      = "${::varnish::version_major}.${::varnish::version_minor}${::varnish::version_lts}" ? {
+        '6.6'    => 'A0378A38E4EACA3660789E570BAC19E3F6C90CD5',
         '6.5'    => 'A487F9BE81D9DF5121488CFE1C7B4E9FF149D65B',
         '6.4'    => 'A9897320C397E3A60C03E8BF821AD320F71BFF3D',
         '6.3'    => '920A8A7AA7120A8604BCCD294A42CD6EB810E55D',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -60,7 +60,7 @@ class varnish::repo {
             fail('Varnish 5.0 from Packagecloud is not supported on Debian 7 (Wheezy)')
           }
 
-          if $::varnish::version_major == '6' and versioncmp($::lsbdistrelease,'8.0') >= 0 {
+          if $::varnish::version_major == '6' and versioncmp($::lsbdistrelease,'8.0') == -1 {
             fail('Varnish 6.0 and above is only supported on Debian 9 (Stretch) and above')
           }
         }

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,8 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     }
   ],

--- a/spec/classes/varnish_spec.rb
+++ b/spec/classes/varnish_spec.rb
@@ -52,8 +52,8 @@ describe 'varnish', type: :class do
               should_fail = 1
             end
           elsif facts[:osfamily] == 'Debian'
-            if facts[:operatingsystem] == 'Debian' && facts[:lsbdistcodename] != 'stretch'
-              it { is_expected.to raise_error(Puppet::Error, %r{Varnish 6.0 and above is only supported on Debian 9 \(Stretch\)}) }
+            if facts[:operatingsystem] == 'Debian' && (facts[:lsbdistcodename] == 'wheezy' || facts[:lsbdistcodename] == 'jessie')
+              it { is_expected.to raise_error(Puppet::Error, %r{Varnish 6.0 and above is only supported on Debian 9 \(Stretch\) and newer}) }
               should_fail = 1
             end
 

--- a/templates/varnish.service.erb
+++ b/templates/varnish.service.erb
@@ -44,7 +44,14 @@ ExecStart=/usr/sbin/varnishd <%= scope['::varnish::config::jail_opt'] %> \
   -p <%= k %>=<%= v %> \
 <% end -%>
   -S <%= scope['::varnish::secret_file'] %> \
-  -s <%= scope['::varnish::storage_type'] %>,<% if scope['::varnish::storage_type'] == 'file' -%><%= scope['::varnish::storage_file'] %>,<% end -%><%= scope['::varnish::storage_size'] %> \
-<% scope['::varnish::storage_additional'].each do |k| -%>
+  -s <%= scope['::varnish::storage_type'] %>,<% if scope['::varnish::storage_type'] == 'file' -%><%= scope['::varnish::storage_file'] %>,<% end -%><%= scope['::varnish::storage_size'] -%>
+<% unless [nil, :undefined, :undef, []].include?(scope['::varnish::storage_additional']) -%>
+ \
+<% end %>
+<% scope['::varnish::storage_additional'].each_with_index do |k, idx| -%>
+<% if (idx + 1 ) == scope['::varnish::storage_additional'].length -%>
+  -s <%= k %>
+<% else -%>
   -s <%= k %> \
+<% end -%>
 <% end -%>

--- a/templates/varnish.service.erb
+++ b/templates/varnish.service.erb
@@ -1,6 +1,9 @@
 [Unit]
 Description=Varnish HTTP accelerator
 
+[Install]
+WantedBy=multi-user.target
+
 [Service]
 Type=forking
 LimitNOFILE=131072
@@ -45,6 +48,3 @@ ExecStart=/usr/sbin/varnishd <%= scope['::varnish::config::jail_opt'] %> \
 <% scope['::varnish::storage_additional'].each do |k| -%>
   -s <%= k %> \
 <% end -%>
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
This will fix the Systemd Unit File:
Just move the [Install] section above [Service]

Adding stretch and above support:
Varnish will also work in buster ;)

Adding gpgkeys:
Add gpgkeys for varnish 6.2 & 6.3