### PR TITLE
Start varnish deamon after network is up - varnish.service.erb

### DIFF
--- a/templates/varnish.service.erb
+++ b/templates/varnish.service.erb
@@ -1,5 +1,6 @@
 [Unit]
 Description=Varnish HTTP accelerator
+After=network.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Starting varnish daemon after network is successfully up.

I've had issues when varnish start up before the network is successfully up, cause he can not resolve dns names without network (ofc).

```
Oct 20 11:22:33 varnishd: Message from VCC-compiler:
Oct 20 11:22:33 varnishd: Backend host '"host.example.com"' could not be resolved to an IP address:
Oct 20 11:22:33 varnishd: Name or service not known
Oct 20 11:22:34 NetworkManager[770]: <info>  [1603185754.0836] NetworkManager (version 1.18.4-3.el7) is starting... (for the first time)
Oct 20 11:22:34 kernel: vmxnet3 0000:03:00.0 ens160: NIC Link is Up 10000 Mbps
```

The Idea is to add the dependency on network.target within the systemd unit:

```
[Unit]
Description=Varnish HTTP accelerator
After=network.target
```