### PR TITLE
Add support for Debian buster

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ please use the latest version [4.x version from the Puppet Forge](https://forge.
 ## Module Description
 
 This module Supports Varnish versions 3.0, 4.0, 4.1, 5.0, 5.1, 5.2,
-6.0, 6.1 across Ubuntu 14.04/16.04/18.04, Debian 7/8/9 and RedHat derivates
+6.0, 6.1 across Ubuntu 14.04/16.04/18.04, Debian 7/8/9/10 and RedHat derivates
 6/7.
 
 This module will install Varnish, **by default version 4.1** from the official

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ please use the latest version [4.x version from the Puppet Forge](https://forge.
 ## Module Description
 
 This module Supports Varnish versions 3.0, 4.0, 4.1, 5.0, 5.1, 5.2,
-6.0, 6.1 across Ubuntu 14.04/16.04/18.04, Debian 7/8/9/10 and RedHat derivates
-6/7.
+6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6 across Ubuntu 14.04/16.04/18.04,
+Debian 7/8/9/10 and RedHat derivates 6/7.
 
 This module will install Varnish, **by default version 4.1** from the official
 Packagecloud repositories, adding EPEL for RedHat-like systems and working

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,8 @@ PUPPET_VERSION = "5.5.10"
 BOXES = [
   { name: "debian7",  box: "debian/wheezy64",  version: "7.11.2" },
   { name: "debian8",  box: "debian/jessie64",  version: "8.11.0" },
-  { name: "debian8",  box: "debian/stretch64", version: "9.8.0" },
+  { name: "debian9",  box: "debian/stretch64", version: "9.8.0" },
+  { name: "debian10", box: "debian/buster64",  version: "10.11.0" },
 
   { name: "ubuntu14", box: "ubuntu/trusty64", version: "20190301.0.1" },
   { name: "ubuntu16", box: "ubuntu/xenial64", version: "20190221.0.0" },

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,11 +37,16 @@ class varnish::params {
     }
 
     'Debian': {
-      $vcl_reload = $varnish::version_major ? {
-        '6' => '/usr/sbin/varnishreload',
-        '5' => '/usr/share/varnish/reload-vcl -q',
-        '4' => '/usr/share/varnish/reload-vcl -q',
-        '3' => '/usr/share/varnish/reload-vcl -q',
+      if versioncmp($varnish::version_full,'6.1') >= 0 and versioncmp($facts['os']['release']['full'],'10.0') >= 0 {
+        $vcl_reload = '/usr/share/varnish/varnishreload'
+      }
+      else {
+        $vcl_reload = $varnish::version_major ? {
+          '6' => '/usr/sbin/varnishreload',
+          '5' => '/usr/share/varnish/reload-vcl -q',
+          '4' => '/usr/share/varnish/reload-vcl -q',
+          '3' => '/usr/share/varnish/reload-vcl -q',
+        }
       }
       $sysconfig  = '/etc/default/varnish'
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -57,8 +57,8 @@ class varnish::repo {
             fail('Varnish 5.0 from Packagecloud is not supported on Debian 7 (Wheezy)')
           }
 
-          if $varnish::version_major == '6' and $facts['os']['distro']['codename'] != 'stretch' {
-            fail('Varnish 6.0 and above is only supported on Debian 9 (Stretch)')
+          if $varnish::version_major == '6' and versioncmp($facts['os']['release']['full'],'9.0') == -1 {
+            fail('Varnish 6.0 and above is only supported on Debian 9 (Stretch) and above')
           }
         }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -86,6 +86,11 @@ class varnish::repo {
       $os_lower        = downcase($facts['os']['name'])
       $package_require = Exec['apt_update']
       $gpg_key_id      = "${varnish::version_major}.${varnish::version_minor}${varnish::version_lts}" ? {
+        '6.6'    => 'A0378A38E4EACA3660789E570BAC19E3F6C90CD5',
+        '6.5'    => 'A487F9BE81D9DF5121488CFE1C7B4E9FF149D65B',
+        '6.4'    => 'A9897320C397E3A60C03E8BF821AD320F71BFF3D',
+        '6.3'    => '920A8A7AA7120A8604BCCD294A42CD6EB810E55D',
+        '6.2'    => 'B54813B54CA95257D3590B3F1B0096460868C7A9',
         '6.1'    => '4A066C99B76A0F55A40E3E1E387EF1F5742D76CC',
         '6.0lts' => '48D81A24CB0456F5D59431D94CFCFD6BA750EDCD',
         '6.0'    => '7C5B46721AF00FD57E68E6E8D2605BF74E8B9DBA',

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,8 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     }
   ],


### PR DESCRIPTION
#### Pull Request (PR) description
As requested on #68 by @fe80 , independent pull request addressing Buster support

Last commit is optional (only adds GPG keys for newer versions)

#### This Pull Request (PR) fixes the following issues
Fixes #63
Fixes #65
Fixes #66
Fixes #67 
Fixes #68 